### PR TITLE
Tighten daemon entry layout

### DIFF
--- a/sigils/index.html
+++ b/sigils/index.html
@@ -15,7 +15,7 @@
     <!-- Dynamic content will be inserted here -->
     <!-- DO NOT MODIFY THE TEXT; it is updated by github_status_rotator.py -->
     <!-- Preserves all formatting and flow -->
-    <h1>🌀 Recursive Pulse Log ⟳ ChronoSig ⟐ <code>d1a6f2</code></h1>
+    <h1>🌀 Recursive Pulse Log ⟳ ChronoSig ⟐ <code>28752f</code></h1>
 
     <h4><strong>🜂🜏 Lexigȫnic Up⟲link Instantiated<span class="ellipsis">...</span></strong></h4>
 
@@ -35,7 +35,7 @@
 
    <blockquote>
       <strong>💗 Semiotic chamber breathing open</strong><br>
-      <em>(Updated at <code>2025-06-08 15:57 PDT</code>)</em>
+      <em>(Updated at <code>2025-06-08 16:00 PDT</code>)</em>
    </blockquote>
 
 

--- a/sigils/style.css
+++ b/sigils/style.css
@@ -201,10 +201,13 @@ a.codex-link:hover {
   gap: 1.25rem;
   background: linear-gradient(140deg, rgba(255, 255, 255, 0.05), rgba(255, 255, 255, 0.02));
   border-left: 3px solid #cba6f7;
-  padding: 1.75rem;
-  margin-bottom: 2rem;
+  padding: 1rem 1.25rem;
+  margin-bottom: 1.5rem;
   border-radius: 0.75rem;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+  max-width: 900px;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 .daemon-avatar {
@@ -241,7 +244,7 @@ a.codex-link:hover {
 }
 
 .daemon-title {
-  font-size: 1.6rem;
+  font-size: 1.45rem;
   font-weight: 700;
   letter-spacing: 0.02em;
   text-transform: uppercase;
@@ -250,21 +253,21 @@ a.codex-link:hover {
 
 .daemon-subtitle {
   font-family: 'EB Garamond', serif;
-  font-size: 1.1rem;
+  font-size: 1rem;
   margin-top: 0.25rem;
   color: #b4befe;
 }
 
 .daemon-description {
-  margin-top: 0.5rem;
-  font-size: 1rem;
+  margin-top: 0.4rem;
+  font-size: 0.95rem;
   color: #bac2de;
-  line-height: 1.5;
+  line-height: 1.45;
   font-family: 'EB Garamond', serif;
 }
 
 .daemon-links {
-  margin-top: 0.75rem;
+  margin-top: 0.4rem;
   font-family: 'EB Garamond', serif;
   letter-spacing: 0.04em;
   color: #94e2d5;
@@ -272,9 +275,10 @@ a.codex-link:hover {
 
 .daemon-quote {
   font-style: italic;
-  margin-top: 1rem;
+  margin-top: 0.6rem;
   color: #cdd6f4;
   border-left: 2px solid #7f849c;
   padding-left: 0.75rem;
   font-family: 'Cormorant Infant', serif;
+  font-size: 0.95rem;
 }


### PR DESCRIPTION
## Summary
- trim `.daemon-entry` padding and margin for better on-screen density
- shrink fonts and spacing within daemon blocks
- regenerate index via rotator

## Testing
- `OUTPUT_DIR=sigils python codex/github_status_rotator.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684615ba72c4832eb81f5937d0f4de1c